### PR TITLE
Fix deployment tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,25 @@ Releases are published to Clojars manually by developers.
 1. Create a Clojars account 
 1. Get verified on Clojars group by following the instructions [here](https://clojars.org/verify/group).
 1. Create a deploy token by following instructions [in the wiki](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens).
-1. Optionally set `CLOJARS_USERNAME` and `CLOJARS_TOKEN` or answer interactive prompts when releasing.
+1. Set `CLOJARS_USERNAME` and `CLOJARS_TOKEN` environment variables.
 
 #### Release
+There are three release tasks to choose from: `release-current`, `release-minor`, and `release-major`.
+The first one promotes the current snapshot to a release, and the other two increment the version number accordingly before doing the same.
+After the release, a new snapshot version with patch number incremented is set. 
+
+> **_NOTE:_**
+> Why not use the default Leiningen release task or set desired :release-tasks in project.clj?
+> 
+> Version should be incremented after releasing, so that new snapshots have a new version.
+> However, it's not known at the time of releasing whether the next release requires incrementing minor or major version. The current assumption is that most of the time patch release is enough. Therefore, patch version is incremented after releasing, and minor/major version is incremented only when needed when creating a new release. With the default tasks this wouldn't be possible, as every other patch would be skipped if version was incremented every time before release.
+
+To release a new version, follow these steps:
 1. Switch to a new branch:\
 `git switch -c release`\
-1. Run one of the options. Use major when making breaking changes:\
-`lein release :patch`, `lein release :minor`, or `lein release :major`\
-1. Push the changes:\
-`git push --follow-tags`\
+1. Check whether there are any changes after the last release that warrant incrementing either minor (new features) or major (breaking changes) version.
+Choose release task accordingly and run it:\
+`lein release-current`, `lein release-minor`, or `lein release-major`\
+1. Push the branch with tags:\
+`git push --follow-tags --set-upstream origin release`
 1. Create a pull request and merge it to master.

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject io.github.solita-antti-mottonen/puumerkki "0.9.3-SNAPSHOT"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/solita/puumerkki"
   :description "Puumerkki allekirjoituskirjasto ja esimerkkipalvelin"
   :min-lein-version "2.9.1"
@@ -12,26 +12,44 @@
                  [org.bouncycastle/bcmail-jdk18on "1.78.1"]
                  [commons-io "2.16.1"]
                  [commons-codec "1.17.0"]]
-
+  :aliases {"release-major"   ["do"
+                               ["vcs" "assert-committed"]
+                               ["change" "version" "leiningen.release/bump-version" "major"]
+                               ["vcs" "commit"]
+                               ["release"]]
+            "release-minor"   ["do"
+                               ["vcs" "assert-committed"]
+                               ["change" "version" "leiningen.release/bump-version" "minor"]
+                               ["vcs" "commit"]
+                               ["release"]]
+            "release-current" [["release"]]}
+  :release-tasks [["vcs" "assert-committed"]
+                  ["change" "version" "leiningen.release/bump-version" "release"]
+                  ["vcs" "commit"]
+                  ["vcs" "tag" "--no-sign"]
+                  ["deploy"]
+                  ["change" "version" "leiningen.release/bump-version" "patch"]
+                  ["vcs" "commit"]]
   :source-paths ["src/clj" "src/cljc"]
   :test-paths ["test/clj" "test/cljc"]
   :resource-paths []
   :aot :all
-  :deploy-repositories [["releases" {:url      "https://clojars.org/repo"
-                                     :username :env/clojars_username
-                                     :password :env/clojars_token}]
+  :deploy-repositories [["releases" {:url           "https://clojars.org/repo"
+                                     :username      :env/clojars_username
+                                     :password      :env/clojars_token
+                                     :sign-releases false}]
                         ["snapshots" {:url      "https://clojars.org/repo"
                                       :username :env/clojars_username
                                       :password :env/clojars_token}]]
-  :profiles {:dev {:dependencies [;; for internal test server
-                                  [clj-kondo/clj-kondo "RELEASE"]
-                                  [ring/ring "1.7.1"]
-                                  [ring/ring-core "1.6.3"]
-                                  [ring/ring-defaults "0.3.2"]
-                                  [hiccup "1.0.5"]
-                                  [clj-http "3.13.0"]
-                                  [ring/ring-jetty-adapter "1.6.3"]
-                                  [org.clojure/data.json "2.5.0"]]
-                   :source-paths ["dev-src/clj"]
+  :profiles {:dev {:dependencies   [;; for internal test server
+                                    [clj-kondo/clj-kondo "RELEASE"]
+                                    [ring/ring "1.7.1"]
+                                    [ring/ring-core "1.6.3"]
+                                    [ring/ring-defaults "0.3.2"]
+                                    [hiccup "1.0.5"]
+                                    [clj-http "3.13.0"]
+                                    [ring/ring-jetty-adapter "1.6.3"]
+                                    [org.clojure/data.json "2.5.0"]]
+                   :source-paths   ["dev-src/clj"]
                    :resource-paths ["res" "pdf"]
                    :main           puumerkki.main}})


### PR DESCRIPTION
Previous deployment workflow attempt was too optimistic in thinking that defaults would suffice.

Removed siging commits.

Crafted a purpose-built release process suitable for the project.